### PR TITLE
Modify neck joint trajectory example

### DIFF
--- a/sciurus17_examples/scripts/neck_joint_trajectory_example.py
+++ b/sciurus17_examples/scripts/neck_joint_trajectory_example.py
@@ -52,6 +52,6 @@ if __name__ == '__main__':
     rospy.sleep(1.0)
     np.set_angle(math.radians(-90.0), math.radians(0.0))
     rospy.sleep(1.0)
-    np.set_angle(math.radians(90.0), math.radians(0.0))
+    np.set_angle(math.radians(80.0), math.radians(0.0))
     rospy.sleep(1.0)
     np.set_angle(math.radians(0.0), math.radians(0.0))


### PR DESCRIPTION
首ジョイントのサンプルについて、上を見上げる角度が可動範囲を超えていた(90度)ので80度に修正しました。