### PR TITLE
Fix uvc camera dependent package

### DIFF
--- a/sciurus17_vision/package.xml
+++ b/sciurus17_vision/package.xml
@@ -49,7 +49,7 @@
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>dynamic_reconfigure</exec_depend>
-  <exec_depend>libuvc_camera</exec_depend>
+  <exec_depend>uvc_camera</exec_depend>
 
   <depend>sciurus17_msgs</depend>
 


### PR DESCRIPTION
#16のchest_cameraが表示されない問題を解決するためのPRです。

該当コメント: https://github.com/rt-net/sciurus17_ros/issues/16#issuecomment-450095662

なお、`uvc_camera`は`libuvc_camera`への移行がアナウンスされているので関連issueとして #17 が存在します。

will close #16