### PR TITLE
Add run depend

### DIFF
--- a/sciurus17_moveit_config/package.xml
+++ b/sciurus17_moveit_config/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>


### PR DESCRIPTION
`sciurus17_moveit_config`の実行に必要なパッケージに`moveit_simple_controller_manager`を追加しました。