### PR TITLE
Set initial_reset:=true in realsense.launch

### DIFF
--- a/sciurus17_vision/launch/realsense.launch
+++ b/sciurus17_vision/launch/realsense.launch
@@ -28,7 +28,7 @@
 
   <arg name="filters"                     default="pointcloud"/>
   <arg name="clip_distance"               default="-1"/>
-  <arg name="initial_reset"               default="false"/>
+  <arg name="initial_reset"               default="true"/>
 
   <remap from="depth/color/points"        to="depth_registered/points"/>
 


### PR DESCRIPTION
realsense.launchのオプションのinitial_resetをtrueにしました。

ただ、Ctrl-Cを押すとrealsenseがクローズされるため、initial_resetの効果は確認できていません。
https://github.com/intel-ros/realsense/pull/571

この変更はおまじないです。

サンプルプログラムが正常に動くことは確認しています。