### PR TITLE
Add prest_pid_gain_example. Fix write_joint_param().

### DIFF
--- a/sciurus17_control/scripts/preset_reconfigure.py
+++ b/sciurus17_control/scripts/preset_reconfigure.py
@@ -31,9 +31,9 @@ class PRESET_RECONFIGURE:
                         ]
         ### プリセット定義 - 初期値 ###
         self.preset_init = []
-        for i in range(len(self.joint_list)):
+        for i in range(17):
             self.preset_init.append( { "p_gain": 800, "i_gain": 0, "d_gain": 0 } )
-        ### プリセット定義 - 1 脱力状態 ###
+        ### プリセット定義 - 1.Free ###
         self.preset_1 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
@@ -52,27 +52,47 @@ class PRESET_RECONFIGURE:
                             { "name":"neck_yaw_joint",  "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"waist_yaw_joint", "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                         ]
-        ### プリセット定義 - 2 左手のみ脱力 ###
-        self.preset_2 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+        ### プリセット定義 - 2 ###
+        self.preset_2 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
                             { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 1500, "i_gain": 0, "d_gain": 0 },\
                         ]
-        ### プリセット定義 - 3 右手のみ脱力 ###
-        self.preset_3 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+        ### プリセット定義 - 3 ###
+        self.preset_3 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 100, "d_gain": 0 },\
+                            { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 100, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 1500, "i_gain": 0, "d_gain": 0 },\
+                        ]
+        ### プリセット定義 - 右手脱力 ###
+        self.preset_free_right_arm = [   
+                            { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
@@ -86,12 +106,33 @@ class PRESET_RECONFIGURE:
                             { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint","p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                         ]
-        ### プリセット定義 - 4 両手の脱力 ###
-        self.preset_4 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+        ### プリセット定義 - 左手脱力 ###
+        self.preset_free_left_arm = [   
+                            { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint","p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                        ]
+        ### プリセット定義 - 両手脱力 ###
+        self.preset_free_two_arms = [   
+                            { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
@@ -105,28 +146,9 @@ class PRESET_RECONFIGURE:
                             { "name":"l_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                        ]
-        ### プリセット定義 - 5 未設定。モノを掴んだ時や、アームの形状を変えた時に合わせて設定してみてください ###
-        self.preset_5 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint","p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                         ]
         ### プリセットデータリスト ###
         self.preset_list = []
@@ -134,8 +156,9 @@ class PRESET_RECONFIGURE:
         self.preset_list.append( self.preset_1 )
         self.preset_list.append( self.preset_2 )
         self.preset_list.append( self.preset_3 )
-        self.preset_list.append( self.preset_4 )
-        self.preset_list.append( self.preset_5 )
+        self.preset_list.append( self.preset_free_right_arm)
+        self.preset_list.append( self.preset_free_left_arm)
+        self.preset_list.append( self.preset_free_two_arms)
 
         self.reconfigure = []
         for joint in self.joint_list:

--- a/sciurus17_control/scripts/preset_reconfigure.py
+++ b/sciurus17_control/scripts/preset_reconfigure.py
@@ -31,9 +31,9 @@ class PRESET_RECONFIGURE:
                         ]
         ### プリセット定義 - 初期値 ###
         self.preset_init = []
-        for i in range(17):
+        for i in range(len(self.joint_list)):
             self.preset_init.append( { "p_gain": 800, "i_gain": 0, "d_gain": 0 } )
-        ### プリセット定義 - 1.Free ###
+        ### プリセット定義 - 1 脱力状態 ###
         self.preset_1 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
@@ -52,43 +52,81 @@ class PRESET_RECONFIGURE:
                             { "name":"neck_yaw_joint",  "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                             { "name":"waist_yaw_joint", "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
                         ]
-        ### プリセット定義 - 2 ###
-        self.preset_2 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 1500, "i_gain": 0, "d_gain": 0 },\
-                        ]
-        ### プリセット定義 - 3 ###
-        self.preset_3 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+        ### プリセット定義 - 2 左手のみ脱力 ###
+        self.preset_2 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 100, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                        ]
+        ### プリセット定義 - 3 右手のみ脱力 ###
+        self.preset_3 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 200, "d_gain": 0 },\
-                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 100, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                             { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
-                            { "name":"waist_yaw_joint",  "p_gain": 1500, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                        ]
+        ### プリセット定義 - 4 両手の脱力 ###
+        self.preset_4 = [   { "name":"r_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 10, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                        ]
+        ### プリセット定義 - 5 未設定。モノを掴んだ時や、アームの形状を変えた時に合わせて設定してみてください ###
+        self.preset_5 = [   { "name":"r_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"r_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint1",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint2",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint3",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint4",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint5",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint6",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"l_arm_joint7",     "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_pitch_joint", "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"neck_yaw_joint",   "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
+                            { "name":"waist_yaw_joint",  "p_gain": 800, "i_gain": 0, "d_gain": 0 },\
                         ]
         ### プリセットデータリスト ###
         self.preset_list = []
@@ -96,6 +134,8 @@ class PRESET_RECONFIGURE:
         self.preset_list.append( self.preset_1 )
         self.preset_list.append( self.preset_2 )
         self.preset_list.append( self.preset_3 )
+        self.preset_list.append( self.preset_4 )
+        self.preset_list.append( self.preset_5 )
 
         self.reconfigure = []
         for joint in self.joint_list:

--- a/sciurus17_control/src/hardware.cpp
+++ b/sciurus17_control/src/hardware.cpp
@@ -285,7 +285,9 @@ int main( int argc, char* argv[] )
             sciurus17.set_gain( gain_data.dxl_id, gain_data.gain );//手間がかかるだけなのでparamとは連動しない
             set_gain_request.pop();
         }
-        while( set_joint_param_request.size() > 0 ){
+        // Dynamixelとの通信タイムアウトを防ぐため、
+        // write_joint_param()は1制御ループで1回のみ実行する
+        if( set_joint_param_request.size() > 0 ){
             write_joint_param( sciurus17, set_joint_param_request.front() );
             set_joint_param_request.pop();
         }

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -266,3 +266,20 @@ rosrun sciurus17_examples depth_camera_tracking.py
                 (700, 900),
                 (800, 1000)]
 ```
+
+---
+
+### preset_pid_gain_example.pyの実行
+
+`sciurus17_control`の`preset_reconfigure`を使うコード例です。
+サーボモータのPIDゲインを一斉に変更できます。
+
+プリセットは[sciurus17_control/scripts/preset_reconfigure.py](../sciurus17_control/scripts/preset_reconfigure.py)
+にて編集できます。
+
+次のコマンドを実行すると、`preset_reconfigure.py`と`preset_pid_gain_example.py`のノードを起動します。
+
+```sh
+roslaunch sciurus17_examples preset_pid_gain_example.launch
+```
+

--- a/sciurus17_examples/launch/preset_pid_gain_example.launch
+++ b/sciurus17_examples/launch/preset_pid_gain_example.launch
@@ -1,0 +1,5 @@
+<launch>
+  <node name="preset_reconfigure" pkg="sciurus17_control" type="preset_reconfigure.py" />
+
+  <node name="preset_pid_gain" pkg="sciurus17_examples" type="preset_pid_gain_example.py" required="true" output="screen" />
+</launch>

--- a/sciurus17_examples/scripts/preset_pid_gain_example.py
+++ b/sciurus17_examples/scripts/preset_pid_gain_example.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import moveit_commander
+
+from std_msgs.msg import UInt8
+
+def preset_pid_gain(pid_gain_no):
+    # サーボモータのPIDゲインをプリセットする
+    # プリセットの内容はsciurus7_control/scripts/preset_reconfigure.pyに書かれている
+    print("PID Gain Preset. No." + str(pid_gain_no))
+    preset_no = UInt8()
+    preset_no.data = pid_gain_no
+    pub_preset.publish(preset_no)
+    rospy.sleep(1) # PIDゲインがセットされるまで待つ
+
+
+def main():
+    rospy.init_node("preset_pid_gain_example")
+    arm = moveit_commander.MoveGroupCommander("two_arm_group")
+    arm.set_max_velocity_scaling_factor(0.1)
+
+    # サーボモータのPIDゲインをプリセット
+    preset_pid_gain(0)
+
+    # SRDFに定義されている"two_arm_init_pose"の姿勢にする
+    print("set named target : two_arm_init_pose")
+    arm.set_named_target("two_arm_init_pose")
+    arm.go()
+
+    # サーボモータのPIDゲインをプリセット
+    # Pゲインが小さくなるので、Sciurus17の両手を人間の手で動かすことが可能
+    preset_pid_gain(4)
+
+    # 動作確認のため数秒間待つ
+    sleep_seconds = 10
+    for i in range(sleep_seconds):
+        print("sleep " + str(sleep_seconds-i) + " seconds.")
+        rospy.sleep(1)
+
+    # 安全のため、現在の両手先姿勢を目標姿勢に変更する
+    print("set target : current arm pose")
+    r_current_pose = arm.get_current_pose("r_link7")
+    l_current_pose = arm.get_current_pose("l_link7")
+    arm.set_pose_target(r_current_pose, "r_link7")
+    arm.set_pose_target(l_current_pose, "l_link7")
+    arm.go()
+
+    # サーボモータのPIDゲインをプリセット
+    preset_pid_gain(0)
+    print("set named target : two_arm_init_pose")
+    arm.set_named_target("two_arm_init_pose")
+    arm.go()
+
+    print("done")
+
+
+if __name__ == '__main__':
+    # PIDゲインプリセット用のPublisher
+    pub_preset = rospy.Publisher("preset_gain_no", UInt8, queue_size=1)
+
+    try:
+        if not rospy.is_shutdown():
+            main()
+    except rospy.ROSInterruptException:
+        pass

--- a/sciurus17_examples/scripts/preset_pid_gain_example.py
+++ b/sciurus17_examples/scripts/preset_pid_gain_example.py
@@ -31,7 +31,7 @@ def main():
 
     # サーボモータのPIDゲインをプリセット
     # Pゲインが小さくなるので、Sciurus17の両手を人間の手で動かすことが可能
-    preset_pid_gain(4)
+    preset_pid_gain(6)
 
     # 動作確認のため数秒間待つ
     sleep_seconds = 10


### PR DESCRIPTION
PIDゲインプリセットのサンプルを追加しました。
[X7のサンプルコード](https://github.com/rt-net/crane_x7_ros/tree/master/crane_x7_examples#preset_pid_gain_examplepyの実行)をコピーしています。

[X7のプルリク](https://github.com/rt-net/crane_x7_ros/pull/82)と同様に、
制御ループ１回につきwrite_joint_param()を１回のみ実行するように変更しています。


