### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,8 @@ ROS Wikiはこちらです。
   従って、SDK(librealsense2-*)をインストールしてください。
 
 - ROSパッケージ[realsense2_camera](http://wiki.ros.org/realsense2_camera)をダウンロード&ビルドします。
-  - ver 2.2.0に対応しています。詳しくは[`Releases`](https://github.com/intel-ros/realsense/releases)を参照してください。
+  - ver 2.2.0に対応しています。詳しくは[`Releases`](https://github.com/IntelRealSense/realsense-ros/releases)を参照してください。
   - **librealsenseとrealsense2_cameraが対応するように適切なバージョンを使用してください**
-  
-  ```bash
-  cd ~/catkin_ws/src/
-  git clone https://github.com/intel-ros/realsense
-  cd ~/catkin_ws
-  catkin_make
-  ```
 
 - 本パッケージをダウンロードします。
 


### PR DESCRIPTION
#67 に向けてREADMEを修正しました。

今後、realsense-rosのインストール方法が変わるかもしれないので、
パッケージのインストール方法は、sciurusのREADMEには書かず、リンク先を参照してもらう方針にします。