### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ sciurus17_ros
 ROS Wikiはこちらです。  
 [https://wiki.ros.org/sciurus17](https://wiki.ros.org/sciurus17)
 
-ROSのサンプルコード集はこちらです。
-
+ROSのサンプルコード集はこちらです。  
 [sciurus17_examples](https://github.com/rt-net/sciurus17_ros/tree/master/sciurus17_examples)
 
 ## 動作環境

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ sciurus17_ros
 ROS Wikiはこちらです。  
 [https://wiki.ros.org/sciurus17](https://wiki.ros.org/sciurus17)
 
+ROSのサンプルコード集はこちらです。
+[sciurus17_examples](https://github.com/rt-net/sciurus17_ros/tree/master/sciurus17_examples)
+
 ## 動作環境
 
 以下の環境にて動作確認を行っています。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ ROS Wikiはこちらです。
 [https://wiki.ros.org/sciurus17](https://wiki.ros.org/sciurus17)
 
 ROSのサンプルコード集はこちらです。
+
 [sciurus17_examples](https://github.com/rt-net/sciurus17_ros/tree/master/sciurus17_examples)
 
 ## 動作環境

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -73,6 +73,8 @@ rosrun sciurus17_examples gripper_action_example.py
 
 動作させると[こちら](https://youtu.be/iTAAUA_fRXw)（[rviz](https://youtu.be/55YOCixB9VI)）のような動きになります。
 
+![gripper_action_example](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_gripper_example.gif)
+
 ---
 
 ### neck_joint_trajectory_example.pyの実行 

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -103,6 +103,8 @@ rosrun sciurus17_examples waist_joint_trajectory_example.py
 
 動作させると[こちら](https://youtu.be/sxu-kN4Qc-o)のような動きになります。
 
+![waist_joint_trajectory_example](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_waist_example.gif)
+
 ---
 
 ### Pick & Place デモの実行

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -88,6 +88,8 @@ rosrun sciurus17_examples neck_joint_trajectory_example.py
 
 動作させると[こちら](https://youtu.be/_4J5bpFNQuI)（[rviz](https://youtu.be/scge_3v7-EA)）のような動きになります。
 
+![neck_joint_trajectory_example](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_neck_example.gif)
+
 ---
 
 ### waist_joint_trajectory_example.pyの実行

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -257,6 +257,8 @@ rosrun sciurus17_examples chest_camera_tracking.py
 
 動作させると[こちら](https://youtu.be/c81I0GaC2DU)のような動きになります。
 
+![chest_camera_tracking](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_chest_camera.gif)
+
 ---
 
 ### depth_camera_tracking.pyの実行

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -117,6 +117,8 @@ rosrun sciurus17_examples pick_and_place_right_arm_demo.py
 
 動作させると[こちら](https://youtu.be/kjaiWhr-dLg)のような動きになります。
 
+![pick_and_place_right_arm](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_pick_and_place_right.gif)
+
 左手でターゲットを掴んで動かすデモ動作を次のコマンドで実行します。
 
 ```

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -185,6 +185,8 @@ def _image_callback(self, ros_image):
 
 動作させると[こちら](https://youtu.be/W39aswfINNU)のような動きになります。
 
+![head_camera_tracking](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_head_camera.gif)
+
   - 動画で使用しているボールは、アールティショップの
 [こちらのページ](https://www.rt-shop.jp/index.php?main_page=product_info&cPath=1299_1307&products_id=3701)
 で購入できます。

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -137,6 +137,8 @@ rosrun sciurus17_examples pick_and_place_two_arm_demo.py
 
 動作させると[こちら](https://youtu.be/GgKYfSm1NY4)（[rviz](https://youtu.be/xo3OiJgu7wg)）のような動きになります。
 
+![pick_and_place_two_arm](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_pick_and_place_two.gif)
+
 ---
 
 ### hand_position_publisherの実行

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -127,6 +127,8 @@ rosrun sciurus17_examples pick_and_place_left_arm_demo.py
 
 動作させると[こちら](https://youtu.be/UycaNEHWbv8)のような動きになります。
 
+![pick_and_place_left_arm](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_pick_and_place_left.gif)
+
 両手でターゲットを掴んで動かすデモ動作を次のコマンドで実行します。
 
 ```

--- a/sciurus17_examples/README.md
+++ b/sciurus17_examples/README.md
@@ -244,6 +244,8 @@ rosrun sciurus17_examples chest_camera_tracking.py
 
 動作させると[こちら](https://youtu.be/wscw-I4wCaM)のような動きになります。
 
+![chest_camera_tracking](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_chest_camera.gif)
+
 *顔追跡とボール追跡の同時実行*
 
 頭カメラと胸のカメラの両方を使って、顔追跡とボール追跡をします。
@@ -256,8 +258,6 @@ rosrun sciurus17_examples chest_camera_tracking.py
 ```
 
 動作させると[こちら](https://youtu.be/c81I0GaC2DU)のような動きになります。
-
-![chest_camera_tracking](https://github.com/rt-net/sciurus17_ros/blob/images/images/gazebo_chest_camera.gif)
 
 ---
 


### PR DESCRIPTION
https://github.com/rt-net/crane_x7_ros/pull/99 と同様の変更です

パット見でサンプルがどのなものか理解できるように、
各サンプルをgazebo上で動かした場合のgitイメージをREADMEに追加します。

- [x] gripper_action_example.pyの実行
- [x] neck_joint_trajectory_example.pyの実行
- [x] waist_joint_trajectory_example.pyの実行
- [x] Pick & Place デモの実行
- [x] hand_position_publisherの実行　（トピックを吐き出すサンプルなのでgif不要）
- [x] head_camera_tracking.pyの実行　（どうにかしてgazeboでやってみる）
- [x] chest_camera_tracking.pyの実行　（どうにかしてgazeboでやってみる）
- [ ] depth_camera_tracking.pyの実行　（どうにかしてgazeboでやってみる）
- [x] preset_pid_gain_example.launchの実行　（実機のサンプルなのでgif不要）


