### PR TITLE
Fix gripper mimic joint angles

### DIFF
--- a/sciurus17_description/urdf/sciurus17_left_hand.xacro
+++ b/sciurus17_description/urdf/sciurus17_left_hand.xacro
@@ -75,7 +75,7 @@
         effort="${hand_joints_effort_limit}" 
         velocity="${hand_joints_velocity_limit}"/>
       <axis xyz="0 0 -1"/>
-      <mimic joint="l_hand_joint" multiplier="-1" offset="0"/>
+      <mimic joint="l_hand_joint" multiplier="1" offset="0"/>
       <dynamics damping="1.0e-6" friction="0.8"/>
     </joint>
 

--- a/sciurus17_description/urdf/sciurus17_right_hand.xacro
+++ b/sciurus17_description/urdf/sciurus17_right_hand.xacro
@@ -76,7 +76,7 @@
         effort="${hand_joints_effort_limit}" 
         velocity="${hand_joints_velocity_limit}"/>
       <axis xyz="0 0 -1"/>
-      <mimic joint="r_hand_joint" multiplier="-1" offset="0"/>
+      <mimic joint="r_hand_joint" multiplier="1" offset="0"/>
       <dynamics damping="1.0e-6" friction="0.8"/>
     </joint>
 


### PR DESCRIPTION
#83 rviz上でGripperの開閉角度が反転していた問題を修正しました。

rvizとgazeboの両方で動作確認しました。

ただ、xacro作成時からmultiplierは-1だったので、
いつから表示が反転していたのか不明です :thinking: 