### PR TITLE
Fix the preset_pid_gain_example to be safe motion.

### DIFF
--- a/sciurus17_examples/scripts/preset_pid_gain_example.py
+++ b/sciurus17_examples/scripts/preset_pid_gain_example.py
@@ -36,13 +36,11 @@ def main():
     # 動作確認のため数秒間待つ
     sleep_seconds = 10
     for i in range(sleep_seconds):
-        print("sleep " + str(sleep_seconds-i) + " seconds.")
+        print( str(sleep_seconds-i) + " counts left.")
         rospy.sleep(1)
-
-    # 安全のため、現在の右手先姿勢を目標姿勢に変更する
-    print("set target : current arm pose")
-    arm.set_pose_target(arm.get_current_pose())
-    arm.go()
+        # 安全のため、現在の右手先姿勢を目標姿勢に変更する
+        arm.set_pose_target(arm.get_current_pose())
+        arm.go()
 
     # サーボモータのPIDゲインをプリセット
     preset_pid_gain(0)

--- a/sciurus17_moveit_config/launch/trajectory_execution.launch.xml
+++ b/sciurus17_moveit_config/launch/trajectory_execution.launch.xml
@@ -11,7 +11,7 @@
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
-  <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.1"/> <!-- default 0.01 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="sciurus17" />


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#102  に対応しました。
目標姿勢の更新頻度を増やすことで、
PIDゲイン復帰後にホームポジションへ戻るような危険な動作を防ぎます。

また、目標姿勢の更新頻度が増えることで、
低PIDゲイン時の制御量が小さくなり、手動操作をスムーズに行えます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#102 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
実機で動作確認しました。


# Any other comments?
<!-- その他コメントはありますか？ -->
CRANE-X7と比べて、アーム移動中に
` ABORTED: Solution found but controller failed during execution`
のエラーが発生する頻度が高いです。
内容は
`Invalid Trajectory: start point deviates from current robot state more than 0.01
joint 'r_arm_joint3': expected: -0.177942, current: -0.16567`
のように、起動の開始姿勢と現在姿勢が離れているものです。

CRANE-X7より軸数が多いことが関係しているかもしれません。

アームを移動させたあと動かさなければエラーは出ないことので、このPRでは修正不要だと考えています。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
