### PR TITLE
Set position pid gain to zero for all joints at shutdown.

### DIFF
--- a/sciurus17_control/include/sciurus17_control/dxlport_control.h
+++ b/sciurus17_control/include/sciurus17_control/dxlport_control.h
@@ -65,6 +65,7 @@ public:
     void                set_param_vol_limit( uint8_t dxl_id, int max, int min );
     void                set_param_current_limit( uint8_t dxl_id, int val );
     void                set_param_vel_gain( uint8_t dxl_id, int p, int i );
+    void                set_param_pos_gain_all( int p, int i, int d );
     void                set_param_pos_gain( uint8_t dxl_id, int p, int i, int d );
 
     bool                is_change_positions( void );

--- a/sciurus17_control/include/sciurus17_control/joint_control.h
+++ b/sciurus17_control/include/sciurus17_control/joint_control.h
@@ -173,6 +173,8 @@ typedef struct ST_JOINT_PARAM
 #define     DXL_PGAIN_MAX                   (16383)
 #define     DXL_DEFAULT_PGAIN               (800)
 #define     DXL_FREE_PGAIN                  (0)
+#define     DXL_FREE_IGAIN                  (0)
+#define     DXL_FREE_DGAIN                  (0)
 
 #define     DXL_OFFSET_DEFAULT              (2048)
 

--- a/sciurus17_control/src/dxlport_control.cpp
+++ b/sciurus17_control/src/dxlport_control.cpp
@@ -1053,6 +1053,17 @@ void DXLPORT_CONTROL::set_param_vel_gain( uint8_t dxl_id, int p, int i )
         }
     }
 }
+
+void DXLPORT_CONTROL::set_param_pos_gain_all( int p, int i, int d )
+{
+    if( !port_stat ){
+        return;
+    }
+    for( int jj=0 ; jj<joint_num ; ++jj ){
+        set_param_pos_gain( joints[jj].get_dxl_id(), p, i, d);
+    }
+}
+
 void DXLPORT_CONTROL::set_param_pos_gain( uint8_t dxl_id, int p, int i, int d )
 {
     uint16_t set_p_param = (uint16_t)p;

--- a/sciurus17_control/src/hardware.cpp
+++ b/sciurus17_control/src/hardware.cpp
@@ -308,7 +308,8 @@ int main( int argc, char* argv[] )
         rate.sleep();
 #endif
     }
-    sciurus17.set_gain_all( DXL_FREE_PGAIN );
+
+    sciurus17.set_param_pos_gain_all( DXL_FREE_PGAIN, DXL_FREE_IGAIN, DXL_FREE_DGAIN );
     sciurus17.set_goal_current_all( 0 );
     spinner.stop();
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#103  の対応です。ノード終了時に全ジョイントのPIDゲインを0にします。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#103 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

通信タイムアウトをOFFした状態でSciurus17を起動します。
その後、preset_reconfigure.pyを使ってPIDゲインを設定し、
ノードをシャットダウンしても、Sciurus17が暴れないことを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->

関連：https://github.com/rt-net/crane_x7_ros/pull/125

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
