### PR TITLE
Add udev rule for BSW500M Web camera

### DIFF
--- a/sciurus17_tools/rules/91-sciurus17.rules
+++ b/sciurus17_tools/rules/91-sciurus17.rules
@@ -1,2 +1,3 @@
 KERNEL=="ttyUSB*", SUBSYSTEM=="tty", ATTRS{idProduct}=="6015", ATTRS{idVendor}=="0403", MODE="0666", SYMLINK+="sciurus17spine", RUN+="/bin/sh -c 'echo 1 > /sys/$DEVPATH/../../latency_timer'"
 KERNEL=="video*", SUBSYSTEM=="video4linux", ATTRS{idProduct}=="708c", ATTRS{idVendor}=="0458", ATTR{index}=="0", SYMLINK+="chestcamera"
+KERNEL=="video*", SUBSYSTEM=="video4linux", ATTRS{idProduct}=="02da", ATTRS{idVendor}=="0411", ATTR{index}=="0", SYMLINK+="chestcamera"


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

BSW500M 用のudevルールを追加します。

デバイスの情報は下記コマンドを実行して確認しました。

`$ udevadm info -q property -n /dev/video1 | grep -E "ID_VENDOR_ID=|ID_MODEL_ID="`

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

udevルール適用後、カメラを接続して`/dev/chestcamera`が表示されることを確認しました。

`$  rosrun sciurus17_examples chest_camera_tracking.py` が動作することを確認しました。



# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
