### PR TITLE
Remove deprecated param 'use_gui'.

### DIFF
--- a/sciurus17_description/launch/display.launch
+++ b/sciurus17_description/launch/display.launch
@@ -3,10 +3,10 @@
   <arg name="state_rate" default="10"/>
 
   <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find sciurus17_description)/urdf/sciurus17.urdf.xacro'" />
-  <param name="use_gui" value="$(arg gui)"/>
   <param name="rate" value="$(arg state_rate)"/>
   <rosparam param="source_list">["/sciurus17/joint_states"]</rosparam>
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"/>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg gui)"/>
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find sciurus17_description)/config/urdf.rviz"/>
 </launch>

--- a/sciurus17_description/package.xml
+++ b/sciurus17_description/package.xml
@@ -15,4 +15,11 @@
 
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>rviz</run_depend>
+  <run_depend>xacro</run_depend>
+
 </package>

--- a/sciurus17_moveit_config/launch/demo.launch
+++ b/sciurus17_moveit_config/launch/demo.launch
@@ -27,10 +27,11 @@
   
 
   <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="$(arg use_gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">
     <rosparam param="/source_list">[/sciurus17/controller1/joint_states,/sciurus17/controller2/joint_states,/sciurus17/controller3/joint_states]</rosparam>
-    <!--rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam-->
+  </node>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg use_gui)">
+    <rosparam param="/source_list">[/sciurus17/controller1/joint_states,/sciurus17/controller2/joint_states,/sciurus17/controller3/joint_states]</rosparam>
   </node>
 
   <include file="$(find sciurus17_control)/launch/sciurus17_control.launch"/>

--- a/sciurus17_moveit_config/launch/sciurus17_planning.launch
+++ b/sciurus17_moveit_config/launch/sciurus17_planning.launch
@@ -25,10 +25,11 @@
   
 
   <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="/use_gui" value="$(arg use_gui)"/>
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg use_gui)">
     <rosparam param="/source_list">[/sciurus17/controller1/joint_states,/sciurus17/controller2/joint_states,/sciurus17/controller3/joint_states]</rosparam>
-    <!--rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam-->
+  </node>
+  <node name="joint_state_publisher_gui" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg use_gui)">
+    <rosparam param="/source_list">[/sciurus17/controller1/joint_states,/sciurus17/controller2/joint_states,/sciurus17/controller3/joint_states]</rosparam>
   </node>
 
   <include file="$(find sciurus17_control)/launch/sciurus17_control.launch" unless="$(arg use_gazebo)"/>

--- a/sciurus17_moveit_config/package.xml
+++ b/sciurus17_moveit_config/package.xml
@@ -19,6 +19,7 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
   <run_depend>joint_state_publisher</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>trac_ik</run_depend>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

`joint_state_publisher`の`use_gui`パラメータは非推奨になり、代わりに`joint_state_publisher_gui`パッケージが用意されました。

`use_gui`パラメータを宣言しているlaunchファイルを修正します。

関連：https://github.com/rt-net/crane_x7_ros/pull/115

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

`display.launch`が動作することを確認しました。

` sciurus17_bringup.launch`でSciurus17が動作することを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作@成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
