### PR TITLE
パラメータ名をstall_velocity_thresholdに修正

### DIFF
--- a/sciurus17_control/config/sciurus17_control1.yaml
+++ b/sciurus17_control/config/sciurus17_control1.yaml
@@ -35,7 +35,7 @@
     joint: r_hand_joint
     action_monitor_rate: 10
     state_publish_rate:  100
-    stalled_velocity_threshold: 0.001
+    stall_velocity_threshold: 0.001
     goal_tolerance: 0.05
     stall_timeout: 0.1
 

--- a/sciurus17_control/config/sciurus17_control2.yaml
+++ b/sciurus17_control/config/sciurus17_control2.yaml
@@ -24,7 +24,7 @@
     joint: l_hand_joint
     action_monitor_rate: 10
     state_publish_rate:  100
-    stalled_velocity_threshold: 0.001
+    stall_velocity_threshold: 0.001
     goal_tolerance: 0.05
     stall_timeout: 0.1
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#112 を修正します。

GripperActionControllerのパラメータ名が間違っていたので修正します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#112 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

パラメータ名修正後に`rosrun sciurus17_examples gripper_action_example.py`を実行し、Gripperが動くことを確認しました。

また、下記のようにthresholdの数値を大きくし、グリッパサンプルを実行します。
そのときに、グリッパの開閉を手で妨害すると、stalled判定になることを確認しました。

```diff
  left_hand_controller:
    type: "position_controllers/GripperActionController"
    publish_rate: 500
    joint: l_hand_joint
    action_monitor_rate: 10
    state_publish_rate:  100
+    stall_velocity_threshold: 10
    goal_tolerance: 0.05
    stall_timeout: 0.1
```

実行結果：

```sh
$ rosrun sciurus17_examples gripper_action_example.py
Initializing node... 
Test - Open Grippers
position: 0.00306796157577
effort: 0.1
stalled: True
reached_goal: False
position: 0.00306796157577
effort: 0.1
stalled: True
reached_goal: False
Test - Close Grippers
position: 0.450990351638
effort: 0.5
stalled: True
reached_goal: False
position: -0.452524332426
effort: 0.5
stalled: True
reached_goal: False
Exiting - Gripper Action Test Example Complete
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
