### PR TITLE
Gripperサンプルの引数修正

### DIFF
--- a/sciurus17_examples/scripts/gripper_action_example.py
+++ b/sciurus17_examples/scripts/gripper_action_example.py
@@ -11,8 +11,8 @@ from control_msgs.msg import (
 )
 import math
 
-CONTROL_L = 0
-CONTROL_R = 1
+CONTROL_R = 0
+CONTROL_L = 1
 
 class GripperClient(object):
     def __init__(self):
@@ -40,38 +40,38 @@ class GripperClient(object):
 
 
     def command(self, position, effort, type):
-        if type == CONTROL_L:
-            self._goalL.command.position = position
-            self._goalL.command.max_effort = effort
-            self._clientL.send_goal(self._goalL,feedback_cb=self.feedbackL)
         if type == CONTROL_R:
             self._goalR.command.position = position
             self._goalR.command.max_effort = effort
             self._clientR.send_goal(self._goalR,feedback_cb=self.feedbackR)
-
-    def feedbackL(self,msg):
-        print("feedbackL")
-        print(msg)
+        if type == CONTROL_L:
+            self._goalL.command.position = position
+            self._goalL.command.max_effort = effort
+            self._clientL.send_goal(self._goalL,feedback_cb=self.feedbackL)
 
     def feedbackR(self,msg):
         print("feedbackR")
         print(msg)
 
+    def feedbackL(self,msg):
+        print("feedbackL")
+        print(msg)
+
     def stop(self):
-        self._clientL.cancel_goal()
         self._clientR.cancel_goal()
+        self._clientL.cancel_goal()
 
     def wait(self, type, timeout=0.1 ):
-        if type == CONTROL_L:
-            self._clientL.wait_for_result(timeout=rospy.Duration(timeout))
-            return self._clientL.get_result()
         if type == CONTROL_R:
             self._clientR.wait_for_result(timeout=rospy.Duration(timeout))
             return self._clientR.get_result()
+        if type == CONTROL_L:
+            self._clientL.wait_for_result(timeout=rospy.Duration(timeout))
+            return self._clientL.get_result()
 
     def clear(self):
-        self._goalL = GripperCommandGoal()
         self._goalR = GripperCommandGoal()
+        self._goalL = GripperCommandGoal()
 
 def main():
     arg_fmt = argparse.RawDescriptionHelpFormatter

--- a/sciurus17_examples/scripts/gripper_action_example.py
+++ b/sciurus17_examples/scripts/gripper_action_example.py
@@ -89,9 +89,9 @@ def main():
     gc.command(math.radians(gripper),0.1,CONTROL_R)
     gripper = -26.0
     gc.command(math.radians(gripper),0.1,CONTROL_L)
-    result = gc.wait(1.0,CONTROL_R)
+    result = gc.wait(CONTROL_R,1.0)
     print(result)
-    result = gc.wait(1.0,CONTROL_L)
+    result = gc.wait(CONTROL_L,1.0)
     print(result)
     time.sleep(1)
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
gripper_action_exampleの引数に正しくない値が入力されていたため修正します。

また左右それぞれのグリッパに関する変数や関数が定義、実行されている順序が項目によって異なっていたため、右手から先に実行する順序に統一しました。こちらの変更は動作には影響しません。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドでサンプルを実行します

```
roslaunch sciurus17_bringup sciurus17_bringup.launch
rosrun sciurus17_examples gripper_action_example.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
