### PR TITLE
サーボ温度がpublishされない問題を修正

### DIFF
--- a/sciurus17_control/src/dxlport_control.cpp
+++ b/sciurus17_control/src/dxlport_control.cpp
@@ -259,6 +259,7 @@ bool DXLPORT_CONTROL::readTemp( ros::Time time, ros::Duration period )
             result = true;
         }
     }
+    ++tempCount;
     return result;
 }
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
コントローラがpublishするtopicリストにサーボ温度が含まれていましたが実際にはpublishされていませんでした。このPRではサーボ温度をpublishするように変更しています。
https://github.com/rt-net/sciurus17_ros/blob/master/sciurus17_control/README.md#ネームスペースとトピック

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドでサーボ温度がpublishされていることを確認しました。

```
rostopic echo /sciurus17/controller1/joints/r_arm_joint1/temp
```

ピックアンドプレースのサンプルが動くことを確認しました。

```
roslaunch sciurus17_bringup sciurus17_bringup.launch
rosrun sciurus17_examples pick_and_place_right_arm_demo.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->
ないです

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
