### PR TITLE
Add image_pipeline dependency to package.xml

### DIFF
--- a/sciurus17_vision/package.xml
+++ b/sciurus17_vision/package.xml
@@ -39,6 +39,7 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_geometry</exec_depend>
+  <exec_depend>image_pipeline</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>image_transport_plugins</exec_depend>
   <exec_depend>pcl_ros</exec_depend>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

https://github.com/rt-net/sciurus17_ros/issues/137
を修正します。
sciurus17_visionの依存関係に、image_pipelineを追加います。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#137 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

Ubuntu 22.04（Docker）において、
roslaunch sciurus17_bringup sciurus17_bringup.launchを実行し、
image_procが無いことによるエラーが表示されないことを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
