### PR TITLE
pick_and_place_tfの時刻計算の改善

### DIFF
--- a/sciurus17_examples/src/pick_and_place_tf.cpp
+++ b/sciurus17_examples/src/pick_and_place_tf.cpp
@@ -126,43 +126,48 @@ private:
     }
 
     rclcpp::Time now = this->get_clock()->now();
-    constexpr std::chrono::nanoseconds FILTERING_TIME = 2s;
-    constexpr std::chrono::nanoseconds STOP_TIME_THRESHOLD = 3s;
-    constexpr double DISTANCE_THRESHOLD = 0.01;
-    tf2::Stamped<tf2::Transform> tf;
-    tf2::convert(tf_msg, tf);
-    const auto TF_ELAPSED_TIME = now.nanoseconds() - tf.stamp_.time_since_epoch().count();
-    const auto TF_STOP_TIME = now.nanoseconds() - tf_past_.stamp_.time_since_epoch().count();
-    constexpr double TARGET_Z_MIN_LIMIT = 0.04;
-    constexpr double TARGET_X_MIN_LIMIT = 0.13;
-    constexpr double TARGET_X_MAX_LIMIT = 0.3;
+    const auto FILTERING_TIME = rclcpp::Duration(2s);
+    const auto STOP_TIME_THRESHOLD = rclcpp::Duration(3s);
+    const double DISTANCE_THRESHOLD = 0.01;
+    const double TARGET_Z_MIN_LIMIT = 0.04;
+    const double TARGET_X_MIN_LIMIT = 0.13;
+    const double TARGET_X_MAX_LIMIT = 0.3;
+
+    tf2::Stamped<tf2::Transform> tf_current;
+    tf2::convert(tf_msg, tf_current);
+
+    const auto tf_elapsed_time = now - rclcpp::Time(tf_msg.header.stamp, RCL_ROS_TIME);
+    const auto tf_stop_time =
+      now - rclcpp::Time(tf_past_.stamp_.time_since_epoch().count(), RCL_ROS_TIME);
 
     // 掴む物体位置を制限する
-    if (tf.getOrigin().z() < TARGET_Z_MIN_LIMIT) {
+    if (tf_current.getOrigin().z() < TARGET_Z_MIN_LIMIT) {
       return;
     }
-    if (tf.getOrigin().x() < TARGET_X_MIN_LIMIT || tf.getOrigin().x() > TARGET_X_MAX_LIMIT) {
+    if (tf_current.getOrigin().x() < TARGET_X_MIN_LIMIT ||
+      tf_current.getOrigin().x() > TARGET_X_MAX_LIMIT)
+    {
       return;
     }
 
     // 検出されてから2秒以上経過した物体は掴まない
-    if (TF_ELAPSED_TIME > FILTERING_TIME.count()) {
+    if (tf_elapsed_time > FILTERING_TIME) {
       return;
     }
 
     // 動いている物体は掴まない
-    double tf_diff = (tf_past_.getOrigin() - tf.getOrigin()).length();
+    double tf_diff = (tf_past_.getOrigin() - tf_current.getOrigin()).length();
     if (tf_diff > DISTANCE_THRESHOLD) {
-      tf_past_ = tf;
+      tf_past_ = tf_current;
       return;
     }
 
     // 物体が3秒以上停止している場合ピッキング動作開始
-    if (TF_STOP_TIME < STOP_TIME_THRESHOLD.count()) {
+    if (tf_stop_time < STOP_TIME_THRESHOLD) {
       return;
     }
 
-    picking(tf.getOrigin());
+    picking(tf_current.getOrigin());
   }
 
   void init_body()


### PR DESCRIPTION
# What does this implement/fix?

ROS 2 Jazzy向けに、`sciurus17_examples`の`pick_and_place_tf.cpp`における把持判定の時刻計算を改善します。

[crane_x7_ros #213](https://github.com/rt-net/crane_x7_ros/pull/213) の変更に合わせ、`std::chrono::nanoseconds`相当の整数比較ではなく、`rclcpp::Duration`を使ってTFの経過時間と停止時間を判定するように変更します。

# Does this close any currently open issues?

しません。

# How has this been tested?

`point_cloud_detection`サンプルを実機で動作させて確認しました。

```bash
$ ros2 launch sciurus17_examples demo.launch.py
```
```bash
$ ros2 launch sciurus17_examples camera_example.launch.py example:=point_cloud_detection
```

# Any other comments?

本PRでは、参考元である [crane_x7_rosのPR](https://github.com/rt-net/crane_x7_ros/pull/213) で行っていた ArUco検出、RGB-D色検出、Pythonサンプル、`image_transport` / `message_filters`依存追加は扱いません。これらは別PRで移植・整理する予定です。

# Checklists

- [x] I have read the CONTRIBUTING guidelines.
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.