### PR TITLE
parallel_gripper_controller対応 のグリッパーコントローラ設定漏れを修正

### DIFF
--- a/sciurus17_control/config/sciurus17_controllers.yaml
+++ b/sciurus17_control/config/sciurus17_controllers.yaml
@@ -5,11 +5,11 @@ controller_manager:
     right_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     right_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
     left_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     left_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
     neck_controller:
       type: joint_trajectory_controller/JointTrajectoryController
     waist_yaw_controller:
@@ -41,6 +41,7 @@ right_gripper_controller:
 
     state_interfaces:
       - position
+      - velocity
 
 left_arm_controller:
   ros__parameters:
@@ -66,6 +67,7 @@ left_gripper_controller:
 
     state_interfaces:
       - position
+      - velocity
 
 neck_controller:
   ros__parameters:


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

parallel_gripper_controller対応https://github.com/rt-net/sciurus17_ros/pull/179 のグリッパーコントローラ設定漏れを修正します。

以前の`parallel_gripper_controller`対応でMoveIt側は`ParallelGripperCommand`を使用する設定になっていましたが、ros2_control側の左右グリッパーコントローラ型が旧`position_controllers/GripperActionController`のまま残り、MoveIt経由でのグリッパーの制御が失敗していました。

本PRでは、その対応漏れを修正し、左右グリッパーのコントローラ型を`parallel_gripper_action_controller/GripperActionController`に変更します。あわせて、parallel版コントローラが要求する `velocity state interface`を追加します。
これにより、実機およびGazeboでMoveIt経由の左右グリッパー開閉動作が復旧することを確認しました。


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

https://github.com/rt-net/sciurus17_ros/issues/185

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

実機とGazeboの両方の環境で`girpper_control`を含む、グリッパーを動かすサンプルが動作することを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
