### PR TITLE
demo.launch.pyにuse_sim_timeを追加

### DIFF
--- a/sciurus17_examples/launch/demo.launch.py
+++ b/sciurus17_examples/launch/demo.launch.py
@@ -72,6 +72,7 @@ def generate_launch_description():
     return LaunchDescription(
         [
             SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
+            declare_use_sim_time,
             declare_use_head_camera,
             declare_use_chest_camera,
             move_group,

--- a/sciurus17_examples/launch/demo.launch.py
+++ b/sciurus17_examples/launch/demo.launch.py
@@ -31,6 +31,12 @@ def generate_launch_description():
         'use_chest_camera', default_value='true', description='Use chest camera.'
     )
 
+    declare_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='false',
+        description=('Set true when using the simulator.'),
+    )
+
     move_group = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
@@ -65,7 +71,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
-            SetParameter(name='use_sim_time', value=True),
+            SetParameter(name='use_sim_time', value=LaunchConfiguration('use_sim_time')),
             declare_use_head_camera,
             declare_use_chest_camera,
             move_group,

--- a/sciurus17_examples/launch/demo.launch.py
+++ b/sciurus17_examples/launch/demo.launch.py
@@ -19,6 +19,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import SetParameter
 
 
 def generate_launch_description():
@@ -64,6 +65,7 @@ def generate_launch_description():
 
     return LaunchDescription(
         [
+            SetParameter(name='use_sim_time', value=True),
             declare_use_head_camera,
             declare_use_chest_camera,
             move_group,


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Gazebo以外のシミュレータにも対応できるようにdemo.launch.pyにuse_sim_timeオプションを追加します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
use_sim_timeがtrueになることを確認しました。

```sh
$ ros2 launch sciurus17_examples demo.launch.py use_sim_time:=true
```

```sh
$ ros2 param get /controller_manager use_sim_time
Boolean value is: True
```

# Any other comments?
<!-- その他コメントはありますか？ -->
ありません。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
